### PR TITLE
Changes to some of the events

### DIFF
--- a/Craftplacer.ClassicSuite.Wizards/Forms/WizardForm.cs
+++ b/Craftplacer.ClassicSuite.Wizards/Forms/WizardForm.cs
@@ -196,7 +196,20 @@ namespace Craftplacer.ClassicSuite.Wizards.Forms
             }
         }
 
-        private void CancelButton_Click(object sender, EventArgs e) => Close();
+        public event CancelEventHandler CancellationRequested;
+
+        private void CancelButton_Click(object sender, EventArgs e)
+        {
+            if (CancellationRequested != null)
+            {
+                CancelEventArgs args = new CancelEventArgs();
+                CancellationRequested?.Invoke(this, args);
+                if (!args.Cancel)
+                    Close();
+            }
+            else
+                Close();
+        }
 
         private void NextButton_Click(object sender, EventArgs e) => NavigateToNextPage();
 

--- a/Craftplacer.ClassicSuite.Wizards/Forms/WizardForm.cs
+++ b/Craftplacer.ClassicSuite.Wizards/Forms/WizardForm.cs
@@ -196,19 +196,18 @@ namespace Craftplacer.ClassicSuite.Wizards.Forms
             }
         }
 
-        public event CancelEventHandler CancellationRequested;
-
         private void CancelButton_Click(object sender, EventArgs e)
         {
-            if (CancellationRequested != null)
+            CancelEventArgs args = new CancelEventArgs();
+
+            LastPage.OnCancelRequested(args);
+
+            if (args.Cancel)
             {
-                CancelEventArgs args = new CancelEventArgs();
-                CancellationRequested?.Invoke(this, args);
-                if (!args.Cancel)
-                    Close();
+                return;
             }
-            else
-                Close();
+
+            Close();
         }
 
         private void NextButton_Click(object sender, EventArgs e) => NavigateToNextPage();

--- a/Craftplacer.ClassicSuite.Wizards/Pages/WizardPage.cs
+++ b/Craftplacer.ClassicSuite.Wizards/Pages/WizardPage.cs
@@ -176,6 +176,20 @@ namespace Craftplacer.ClassicSuite.Wizards.Pages
 
         #endregion Navigation Events
 
+        #region Cancellation
+
+        /// <summary>
+        /// Occurs when the parent WizardForm tries to cancel the wizard process.
+        /// </summary>
+        public event CancelEventHandler CancellationRequested;
+
+        public void OnCancelRequested(CancelEventArgs e)
+        {
+            CancellationRequested?.Invoke(this, e);
+        }
+
+        #endregion
+
         #region Buttons
 
         /// <summary>

--- a/Craftplacer.ClassicSuite.Wizards/Pages/WizardPage.cs
+++ b/Craftplacer.ClassicSuite.Wizards/Pages/WizardPage.cs
@@ -145,7 +145,7 @@ namespace Craftplacer.ClassicSuite.Wizards.Pages
         /// <summary>
         /// Raises the <see cref="NextPageRequested"/> event.
         /// </summary>
-        protected void OnNextPageRequested()
+        public void OnNextPageRequested()
         {
             NextPageRequested?.Invoke(this, EventArgs.Empty);
         }


### PR DESCRIPTION
I made two changes:

- I made an event for when the user presses Cancel. This can be used to create a page that says something like "Wizard failed".
- I made WizardPage.OnNextPageRequested public because there should be a way to navigate through the wizard from outside the WizardPage and WizardForm classes.